### PR TITLE
Add 'generic-microcode' flavor

### DIFF
--- a/generic-microcode.toml
+++ b/generic-microcode.toml
@@ -1,0 +1,13 @@
+# Generic ISO image including AMD & Intel microcode, for usage on bare-metal deployments.
+
+image_format = "iso"
+
+packages = [
+    "intel-microcode",
+    "amd64-microcode"
+]
+
+[additional_repositories.firmware]
+url = "https://ftp.debian.org/debian"
+components = "non-free-firmware"
+no_source = true


### PR DESCRIPTION
## Change Summary
Added `generic-microcode` flavor which incorporates Intel & AMD microcode packages.
This can be useful in bare metal deployments, where a CPU requires updated microcode to patch vulnerabilities.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/.github/blob/current/CONTRIBUTING.md) document